### PR TITLE
Remove strangler comma from package.json, fixes npm install bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "gulp-zip":"^2.0.1",
     "mocha":"^2.1.0",
     "chai":"^1.10.0",
-    "chai-as-promised":"^4.1.1",
+    "chai-as-promised":"^4.1.1"
   }
 }


### PR DESCRIPTION
`npm install` fails on master, this removes the extra comma causing it.

cheers,
nathan